### PR TITLE
html名変更に伴うパスの変更

### DIFF
--- a/src/main/java/com/example/demo/Controller/StackController.java
+++ b/src/main/java/com/example/demo/Controller/StackController.java
@@ -41,7 +41,7 @@ public class StackController {
 			@ModelAttribute StackForm stackForm, @AuthenticationPrincipal LoginUser loginUser, Model model) {
 		stackForm.setTraCourseID(traCourse_ID);
 		model.addAttribute("group", authenticationMapper.selectGroupByUsername(loginUser.getUsername()));
-		return "participant/traCourse/detail";
+		return "participant/traCourse/tracoursedetail";
 	}
 	
 	


### PR DESCRIPTION
htmlのファイル名を変更した際にコントローラのパス名を変更し忘れていたので修正いたしました。